### PR TITLE
Use ieeprep instead of pymef

### DIFF
--- a/bpc-requirements.txt
+++ b/bpc-requirements.txt
@@ -10,7 +10,7 @@ pybids
 nibabel
 nilearn
 
-pymef == 1.3.4
+ieegprep >= 1.4.1
 
 tqdm
 ipykernel

--- a/bpc_interactive.ipynb
+++ b/bpc_interactive.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "This project was supported by the National Institute Of Mental Health of the National Institutes of Health under Award Number R01MH122258. The content is solely the responsibility of the authors and does not necessarily represent the official views of the National Institutes of Health\n",
     "\n",
-    "This Jupyter Notebook was written by Tal Pal Attia, Harvey Huang and Dora Hermes (2021)."
+    "This Jupyter Notebook was written by Tal Pal Attia, Harvey Huang, Max van den Boom and Dora Hermes (2021)."
    ]
   },
   {
@@ -84,7 +84,7 @@
     "\n",
     "We use several Python packages, and the following allow us to work with the BIDS dataset in this notebook:\n",
     " - [PyBIDS](https://bids-standard.github.io/pybids/#) ([Yarkoni et al., 2019](https://joss.theoj.org/papers/10.21105/joss.01294)), a Python library to centralize interactions with BIDS datasets. For more information on BIDS, see: [https://bids.neuroimaging.io](https://bids.neuroimaging.io).\n",
-    " - [Pymef](https://pymef.readthedocs.io/en/latest/index.html#), a wrapper library for Multiscale Electrophysiology Format (MEF). For more information on MEF, see: [https://readthedocs.org/projects/pymef/downloads/pdf/latest/](https://readthedocs.org/projects/pymef/downloads/pdf/latest/)"
+    " - [IeegPrep](https://pypi.org/project/ieegprep/), a python library to read, pre-process and epoch Intracranial Electroencephalography (iEEG) data that is structured according to the Brain Imaging Data Structure (BIDS)"
    ]
   },
   {
@@ -99,6 +99,7 @@
     "# for scientific computing and data visualization \n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "from ieegprep import IeegDataReader\n",
     "from scipy import signal\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.cm as cm\n",
@@ -108,7 +109,6 @@
     "\n",
     "# for handling neuroimaging data\n",
     "import bids\n",
-    "from pymef.mef_session import MefSession\n",
     "from nilearn import plotting\n",
     "\n",
     "# for this tutorial\n",
@@ -354,11 +354,7 @@
     "                               ((df_channels[\"type\"] == 'ECOG') | (df_channels[\"type\"] == 'SEEG'))] \n",
     "# df_good_channels.head()\n",
     "\n",
-    "# All Pymef operations are handled through pymef.mef_session.MefSession.\n",
-    "session_path = mefName # path (absolute or relative) to the MEF3 session folder\n",
-    "password = '' # Pass empty string/variable if not encrypted \n",
-    "# Either for reading\n",
-    "ms = MefSession(session_path, password)\n",
+    "reader = IeegDataReader(mefName, preload_data=False)\n",
     "\n",
     "# To obtain information about time series channels we can use the Pymef function read_ts_channel_basic_info()\n",
     "# ms.read_ts_channel_basic_info()\n",
@@ -401,7 +397,7 @@
     "    # Read mef3 data\n",
     "    for channel in df_electrodes.name:\n",
     "        # pyMef does not apply unit conversion to microVolt, apply Natus conversion factor 0.2658 here after pyMef\n",
-    "        data = 0.2658 * ms.read_ts_channels_sample(channel, [samples])  # Returns 1D numpy array with data from sample X to sample Y\n",
+    "        data = 0.2658 * reader.retrieve_sample_range_data(sample_start=samples[0], sample_end=samples[1], channels=channel)[0]  # Returns 1D numpy array with data from sample X to sample Y\n",
     "        curr_channel = pd.DataFrame({'channel': channel, 'data': [data]})\n",
     "        df_data = pd.concat([df_data, curr_channel], ignore_index=True)  # append to mef3 data dataframe\n",
     "    \n",


### PR DESCRIPTION
Optional adjustment to the original notebook to use IeegPrep instead of PyMef, so you can also load BrainVision or EDF data